### PR TITLE
Fixed incorrect schema configuration.

### DIFF
--- a/backend/deploy-cfn.yml
+++ b/backend/deploy-cfn.yml
@@ -182,7 +182,7 @@ Resources:
     Properties:
       ApiId: !GetAtt chatQLApi.ApiId
       Definition: |
-        type schema {
+        schema {
           query: Query
           mutation: Mutation
           subscription: Subscription

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -1,4 +1,4 @@
-type schema {
+schema {
   query: Query
   mutation: Mutation
   subscription: Subscription


### PR DESCRIPTION
*Description of changes:*

With the current schema defined for ChatQL API, the requests were failing with
`Schema is not configured for root query.`
`Schema is not configured for subscriptions.`
`Schema is not configured for mutations.`

Following the [AWS AppSync docs](https://docs.aws.amazon.com/appsync/latest/devguide/designing-your-schema.html), I found that the `type` is not defined for schema.

Removing `type` and updating the ChatQL schema resolved all issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
