### PR TITLE
Fixing Schema Definition in CFN template

### DIFF
--- a/backend/deploy-cfn.yml
+++ b/backend/deploy-cfn.yml
@@ -182,7 +182,7 @@ Resources:
     Properties:
       ApiId: !GetAtt chatQLApi.ApiId
       Definition: |
-        type schema {
+        schema {
           query: Query
           mutation: Mutation
           subscription: Subscription


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the graphql root schema definition is like the following which is incorrect.

```
type schema {
          query: Query
          mutation: Mutation
          subscription: Subscription
        }

type Query{..}
type Mutation{..}
type Subscription{..}
```
This will create an Output object of type "schema". Right now, AppSync doesn't throw any errors because, AppSync considers `Query`, `Mutation` and `Subscription` as the default names for declaring queries, mutations, and subscriptions. Since the rest of the schema uses these default values, AppSync doesn't throw any error.

You will see AppSync throw errors when you try to use custom names like
```
type schema {
          query: CustomQuery
          mutation: CustomMutation
          subscription: CustomSubscription
        }
type CustomQuery{..}
type CustomMutation{..}
type CustomSubscription{..}
```

The right format is 
```
schema {
          query: Query
          mutation: Mutation
          subscription: Subscription
        }
```

Currently, due to some inconsistencies with AppSync when you use IAM authentication in this project, AppSync starts throwing weird errors due to the above-mentioned issue. Somehow, this schema works for rest of the authentication types. This PR fixes the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
