### PR TITLE
Add attributes to prevent reverse tabnabbing

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -7,7 +7,7 @@
         <amplify-authenticator></amplify-authenticator>
       </div>
       <div class="bg-light">
-        <a href="https://aws.amazon.com/appsync" target="_blank"><img class="img-fluid img-responsive mx-auto d-block appsync" src="../../assets/img/AppSync.png" alt="AWS AppSync"></a>
+        <a rel="noopener noreferrer" href="https://aws.amazon.com/appsync" target="_blank"><img class="img-fluid img-responsive mx-auto d-block appsync" src="../../assets/img/AppSync.png" alt="AWS AppSync"></a>
         <br/>
       </div>
     </div>


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Adds "noopener noreferrer" to rel attribute for the external link. This prevent the target page
from accessing the source page and to omit the `Referer` header.

For more details see:

- https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener
- https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
